### PR TITLE
Added DivideAndScan tool

### DIFF
--- a/sources/install.sh
+++ b/sources/install.sh
@@ -1440,6 +1440,21 @@ function install_ntlm-scanner() {
   git -C /opt/tools/ clone https://github.com/preempt/ntlm-scanner
 }
 
+function install_rustscan() {
+  colorecho "Installing RustScan"
+  mkdir /opt/tools/rustscan/
+  wget -qO- https://api.github.com/repos/RustScan/RustScan/releases/latest | grep "browser_download_url.*amd64.deb" | cut -d: -f2,3 | tr -d \" | wget -qO /opt/tools/rustscan/rustscan.deb -i-
+  dpkg -i /opt/tools/rustscan/rustscan.deb
+  wget https://gist.github.com/snovvcrash/c7f8223cc27154555496a9cbb4650681/raw/a76a2c658370d8b823a8a38a860e4d88051b417e/rustscan-ports-top1000.toml -O /root/.rustscan.toml
+}
+
+function install_divideandscan() {
+  colorecho "Installing DivideAndScan"
+  git -C /opt/tools/ clone https://github.com/snovvcrash/DivideAndScan
+  cd /opt/tools/DivideAndScan
+  python3 -m pip install .
+}
+
 function install_base() {
   update || exit
   fapt man                        # Most important
@@ -1512,6 +1527,7 @@ function install_base() {
   fapt rar                        # rar
   fapt unrar                      # unrar
   fapt xz-utils                   # xz (de)compression
+  fapt xsltproc                   # apply XSLT stylesheets to XML documents (Nmap reports)
   install_pipx
 }
 
@@ -1830,6 +1846,8 @@ function install_network_tools() {
   fapt iproute2                   # Firewall rules
   fapt tcpdump                    # Capture TCP traffic
   install_dnschef                 # Python DNS server
+  install_rustscan                # Fast port scanner
+  install_divideandscan           # Python project to automate port scanning routine
 }
 
 # Package dedicated to wifi pentest tools

--- a/sources/zsh/history
+++ b/sources/zsh/history
@@ -268,4 +268,9 @@ ntlm-scanner -vuln CVE-2019-1019 -target 'BREAKING.BAD'/'someuser':'somepassword
 ntlm-scanner -vuln CVE-2019-1338 -target 'BREAKING.BAD'/'someuser':'somepassword'@'DC01.BREAKING.BAD'
 ntlm-scanner -vuln CVE-2019-1166 -target 'BREAKING.BAD'/'someuser':'somepassword'@'DC01.BREAKING.BAD'
 ntlm-scanner -vuln CVE-2019-1040 -target 'BREAKING.BAD'/'someuser':'somepassword'@'DC01.BREAKING.BAD'
+das add -db dbname masscan '-e eth0 --rate 1000 -iL hosts.txt --open -p1-65535'
+das add -db dbname rustscan '-b 1000 -t 2000 -u 5000 -a hosts.txt -r 1-65535 -g --no-config --scan-order "Random"'
+das scan -db dbname -hosts all -oA report1 -nmap '-Pn -sVC -O' -parallel
+das scan -db dbname -ports 22,80,443,445 -show
+das report -hosts 192.168.1.0/24 -oA report2
 # -=-=-=-=-=-=-=- YOUR COMMANDS BELOW -=-=-=-=-=-=-=- #


### PR DESCRIPTION
Hey @ShutdownRepo!

In this PR I'd like bring [DivideAndScan](https://github.com/snovvcrash/DivideAndScan) tool to Exegol.

It is used to efficiently automate port scanning routine by splitting it into 3 phases:

1. Discover open ports for a bunch of targets.
2. Run Nmap individually for each target with version grabbing and NSE actions.
3. Merge the results into a single Nmap report (different formats available).

For the 1st phase a *fast* port scanner is intended to be used ([Masscan](https://github.com/robertdavidgraham/masscan) / [RustScan](https://github.com/RustScan/RustScan)), whose output is parsed and stored in a database ([TinyDB](https://github.com/msiemens/tinydb)). Next, during the 2nd phase individual Nmap scans are launched for each target with its set of open ports (multiprocessing is supported) according to the database data. Finally, in the 3rd phase separate Nmap outputs are merged into a single report in different formats (XML / HTML / Simple text / Grepable) with [nMap_Merger](https://github.com/CBHue/nMap_Merger).

Potential use cases:

* Pentest engagements / red teaming with a large scope to enumerate.
* Cybersecurity wargames / training CTF labs.
* OSCP certification exam.

For the description of how DivideAndScan works and for some usage examples, please refer to [snovvcrash/DivideAndScan#README](https://github.com/snovvcrash/DivideAndScan/blob/main/README.md#how-it-works).

Cheers!