### PR TITLE
Fixed autorecon install

### DIFF
--- a/sources/install.sh
+++ b/sources/install.sh
@@ -542,9 +542,11 @@ function pykek() {
 
 function install_autorecon() {
   colorecho "Installing autorecon"
+  apt-get -y install wkhtmltopdf oscanner tnscmd10g
   git -C /opt/tools/ clone https://github.com/Tib3rius/AutoRecon
   cd /opt/tools/AutoRecon/
   python3 -m pip install -r requirements.txt
+  chmod +x /opt/tools/AutoRecon/autorecon.py
 }
 
 function install_simplyemail() {


### PR DESCRIPTION
Hey!

A small pull request to install missing optional dependencies for autorecon, and making the python script executable by default as it was not.

Please let me know if you needed an issue for this, I will create it :slightly_smiling_face: .

Trace:

```
[Dec 23, 2021 - 12:42:06 (UTC)] exegol-stable /data # autorecon 192.168.176.247
zsh: permission denied: /opt/tools/AutoRecon/autorecon.py
[Dec 23, 2021 - 12:49:25 (UTC)] exegol-stable /data # chmod +x /opt/tools/AutoRecon/autorecon.py
[Dec 23, 2021 - 12:49:27 (UTC)] exegol-stable /data # autorecon 192.168.176.247
[!] The wkhtmltoimage program could not be found. Make sure it is installed. (On Kali, run: sudo apt install wkhtmltopdf)
[!] The oscanner program could not be found. Make sure it is installed. (On Kali, run: sudo apt install oscanner)
[!] The tnscmd10g program could not be found. Make sure it is installed. (On Kali, run: sudo apt install tnscmd10g)
```

Thanks again for the great tools :+1: 