### PR TITLE
Fix GUI application for wayland compositor

### DIFF
--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -260,6 +260,7 @@ class ContainerConfig:
             self.removeVolume(container_path="/tmp/.X11-unix")
             self.removeEnv("DISPLAY")
             self.removeEnv("QT_X11_NO_MITSHM")
+            self.removeEnv("_JAVA_AWT_WM_NONREPARENTING")
 
     def enableSharedTimezone(self):
         """Procedure to enable shared timezone feature"""
@@ -773,7 +774,7 @@ class ContainerConfig:
         result = ''
         for k, v in self.__envs.items():
             # Blacklist technical variables, only shown in verbose
-            if not verbose and k in ["QT_X11_NO_MITSHM", "DISPLAY", "PATH"]:
+            if not verbose and k in ["_JAVA_AWT_WM_NONREPARENTING", "QT_X11_NO_MITSHM", "DISPLAY", "PATH"]:
                 continue
             result += f"{k}={v}{os.linesep}"
         return result

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -249,6 +249,7 @@ class ContainerConfig:
             self.addVolume(GuiUtils.getX11SocketPath(), "/tmp/.X11-unix")
             self.addEnv("DISPLAY", GuiUtils.getDisplayEnv())
             self.addEnv("QT_X11_NO_MITSHM", "1")
+            self.addEnv("_JAVA_AWT_WM_NONREPARENTING", "1")
             # TODO support pulseaudio
 
     def __disableGUI(self):


### PR DESCRIPTION
When using wayland compositor (in my case *sway*) some graphic applications (*ghidra* and *jd-gui* at least) have blank windows or weird size (for *burp*). Setting **_JAVA_AWT_WM_NONREPARENTING** to **1** seems to fix the problem. 

Source: https://discourse.ubuntu.com/t/environment-variables-for-wayland-hackers/12750