### PR TITLE
Remove dangerous command from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Below are some bullet points to better understand how Exegol works
 You need :
 - git
 - python3 
-- docker (running and accessible from user context. Tips for running docker without sudo: `sudo usermod -aG docker $(id -u -n)`)
+- docker (running and accessible from user context ; check the [docker documentation](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to manage docker as a non-root user)
 - and at least 20GB of free storage
 
 You also need python libraries listed in [requirements.txt](./requirements.txt) (installed automatically or manually depending on the installation method you choose).


### PR DESCRIPTION
The README states the following in the pre-requisites: 
`Tips for running docker without sudo: sudo usermod -aG docker $(id -u -n)`

This commands adds the current user to the docker group ; granting privileges equivalent to root.

I believe that we should send the user to the docker documentation so that they can understand (be afraid of the big red box!) the security concerns emerging from managing docker as a non-root user.

They can also look at the alternatives (docker in rootless mode).